### PR TITLE
Added libgloss/libnosys building to the gcc linaro portfile

### DIFF
--- a/darwin/macports/ports/cross/arm-none-eabi-gcc-linaro/Portfile
+++ b/darwin/macports/ports/cross/arm-none-eabi-gcc-linaro/Portfile
@@ -50,6 +50,7 @@ extract.only            gcc-linaro-${version}.tar.bz2
 post-extract    {
         system "cd ${workpath} && gzip -dc ${distpath}/newlib-${newlibversion}.tar.gz | tar -xf -"
         system "ln -s ${workpath}/newlib-${newlibversion}/newlib ${workpath}/gcc-linaro-${version}/"
+        system "ln -s ${workpath}/newlib-${newlibversion}/libgloss ${workpath}/gcc-linaro-${version}/"
 }
 
 patch.dir              ${workpath}/gcc-linaro-${version}


### PR DESCRIPTION
Patch tested on stm32 (lisa/l) autopilot build. Seems not to break anything here. Please test on an lpc target first before pulling.
