### PR TITLE
changed jsbsim port to use July 15, 2011 version, as per the pprz debian...

### DIFF
--- a/darwin/macports/ports/devel/jsbsim/Portfile
+++ b/darwin/macports/ports/devel/jsbsim/Portfile
@@ -2,7 +2,7 @@
 # $Id$
 PortSystem              1.0
 name                    jsbsim
-version                 trunk-2011.11.28.01
+version                 trunk-2011.07.15.01
 categories              devel
 platforms               darwin
 maintainers             nomaintainer
@@ -11,6 +11,7 @@ long_description        An open source, platform-independent, flight dynamics & 
 homepage                http://jsbsim.sourceforge.net/
 fetch.type              cvs
 cvs.root                :pserver:anonymous@jsbsim.cvs.sourceforge.net:/cvsroot/jsbsim
+cvs.date                "15-July-2011"
 cvs.module 		JSBSim
 
 worksrcdir		JSBSim 
@@ -27,8 +28,8 @@ patchfiles              patch-src-Makefile-am.diff \
                         patch-src-simgear-magvar-Makefile-am.diff \
                         patch-src-simgear-misc-Makefile-am.diff \
                         patch-src-simgear-props-Makefile-am.diff \
-                        patch-src-simgear-xml-Makefile-am.diff \
-                        patch-src-simgear-structure-Makefile-am.diff
+                        patch-src-simgear-xml-Makefile-am.diff
+#                        patch-src-simgear-structure-Makefile-am.diff
 
 use_configure           yes
 pre-configure {


### PR DESCRIPTION
... package, seems to work now, changed version to match, commented out last patch file as this wasn't applicable in jsbsim until about november 19, 2011

This should fix Issue #31 and https://github.com/paparazzi/paparazzi/issues/155
