### PR TITLE
added gsl as a dependency for paparazzi-tools, needed for nps

### DIFF
--- a/darwin/macports/ports/devel/paparazzi-tools/Portfile
+++ b/darwin/macports/ports/devel/paparazzi-tools/Portfile
@@ -39,7 +39,7 @@ depends_lib-append  \
                     port:libopencm3 \
                     port:jsbsim \
                     port:tkdiff \
-                    port:gsl
+                    port:ocaml-gsl
 #found in paparazzi extras port:py26-scipy
 
 distfiles


### PR DESCRIPTION
I think after this gets added in the PortIndex file needs to be updated by running the command "portindex" inside paparazzi-portability-support/darwin/macports/ports

This should fix Issue #33
