### PR TITLE
updated JSBSim port again to match new debian package, cvs date june 12, 2012

### DIFF
--- a/darwin/macports/ports/PortIndex
+++ b/darwin/macports/ports/PortIndex
@@ -23,7 +23,7 @@ portdir devel/ivy-c description {Ivy bus C library} homepage http://www.tls.cena
 ivy-ocaml 365
 portdir devel/ivy-ocaml description {Ivy bus ocaml library} homepage http://www.tls.cena.fr/products/ivy/ epoch 0 platforms darwin name ivy-ocaml depends_lib {port:caml-ocamlnet port:ivy-c} license unknown maintainers nomaintainer long_description {Ivy is the software bus that will creep over your network!} categories devel version r3443-2012.01.24.01 revision 0
 jsbsim 411
-variants universal portdir devel/jsbsim description {JSBsim flight dynamics & control software library} depends_fetch bin:cvs:cvs homepage http://jsbsim.sourceforge.net/ epoch 0 platforms darwin name jsbsim long_description {An open source, platform-independent, flight dynamics & control software library in C++} maintainers nomaintainer license unknown categories devel version trunk-2011.07.15.01 revision 0
+variants universal portdir devel/jsbsim description {JSBsim flight dynamics & control software library} depends_fetch bin:cvs:cvs homepage http://jsbsim.sourceforge.net/ epoch 0 platforms darwin name jsbsim long_description {An open source, platform-independent, flight dynamics & control software library in C++} maintainers nomaintainer license unknown categories devel version trunk-2012.06.12.01 revision 0
 paparazzi 381
 portdir devel/paparazzi depends_fetch bin:git:git-core description {Paparazzi source code} homepage http://paparazzi.enac.fr/Wiki epoch 0 platforms darwin name paparazzi depends_lib port:paparazzi-tools license unknown maintainers nomaintainer long_description {The requirements for building and developing with Paparazzi.} categories devel version master-2011.07.23.01 revision 0
 paparazzi-extras 445

--- a/darwin/macports/ports/devel/jsbsim/Portfile
+++ b/darwin/macports/ports/devel/jsbsim/Portfile
@@ -2,7 +2,7 @@
 # $Id$
 PortSystem              1.0
 name                    jsbsim
-version                 trunk-2011.07.15.01
+version                 trunk-2012.06.12.01
 categories              devel
 platforms               darwin
 maintainers             nomaintainer
@@ -11,7 +11,7 @@ long_description        An open source, platform-independent, flight dynamics & 
 homepage                http://jsbsim.sourceforge.net/
 fetch.type              cvs
 cvs.root                :pserver:anonymous@jsbsim.cvs.sourceforge.net:/cvsroot/jsbsim
-cvs.date                "15-July-2011"
+cvs.date                "12-June-2012"
 cvs.module 		JSBSim
 
 worksrcdir		JSBSim 


### PR DESCRIPTION
Only NPS was broken with JSBSim (rotorcraft sim), this will be fixed soon. This pull request should be merged once that occurs, and a new binary installer built as well.
