### PR TITLE
Update jsbsim to the current trunk & make compile on mavericks.

### DIFF
--- a/darwin/macports/ports/devel/jsbsim/Portfile
+++ b/darwin/macports/ports/devel/jsbsim/Portfile
@@ -2,8 +2,8 @@
 # $Id$
 PortSystem              1.0
 name                    jsbsim
-version                 trunk-2012.06.12
-revision                2
+version                 trunk-2013.10.19
+revision                1
 categories              devel
 platforms               darwin
 maintainers             nomaintainer
@@ -12,7 +12,7 @@ long_description        An open source, platform-independent, flight dynamics & 
 homepage                http://jsbsim.sourceforge.net/
 fetch.type              cvs
 cvs.root                :pserver:anonymous@jsbsim.cvs.sourceforge.net:/cvsroot/jsbsim
-cvs.date                "12-June-2012"
+cvs.date                "19-October-2013"
 cvs.module 		      JSBSim
 
 depends_lib-append      port:autoconf \
@@ -35,7 +35,8 @@ patchfiles              patch-src-Makefile-am.diff \
                         patch-src-simgear-misc-Makefile-am.diff \
                         patch-src-simgear-props-Makefile-am.diff \
                         patch-src-simgear-xml-Makefile-am.diff \
-                        patch-src-simgear-structure-Makefile-am.diff
+                        patch-src-simgear-structure-Makefile-am.diff \
+			patch-src-input_output-string_utilities-h.diff
 
 use_configure           yes
 pre-configure {

--- a/darwin/macports/ports/devel/jsbsim/files/patch-src-input_output-string_utilities-h.diff
+++ b/darwin/macports/ports/devel/jsbsim/files/patch-src-input_output-string_utilities-h.diff
@@ -1,0 +1,11 @@
+--- src/input_output/string_utilities.h-orig	2013-10-24 13:56:18.000000000 -0700
++++ src/input_output/string_utilities.h	2013-10-24 13:56:39.000000000 -0700
+@@ -70,7 +70,7 @@
+   extern std::string& to_lower(std::string& str);
+   extern bool is_number(const std::string& str);
+   std::vector <std::string> split(std::string str, char d);
+-  extern std::string to_string(int);
++  //extern std::string to_string(int);
+   extern std::string replace(std::string str, const std::string& old, const std::string& newstr);
+ #else
+   #include <cctype>


### PR DESCRIPTION
This should be tested on older OSX before being merged. I tried to compile nps using the newer version of jsbsim and it definitely needs updating. PropertyManager vs. PropertyNode classes got restructured a bit. I do not understand enough about the simulation stuff to confidently update nps code to the newer version of jsbsim so I would appreciated some help with that. :)