### PR TITLE
[Darwin jsbsim] Backported pkgconfig patches from debian.

### DIFF
--- a/darwin/macports/ports/devel/jsbsim/Portfile
+++ b/darwin/macports/ports/devel/jsbsim/Portfile
@@ -18,7 +18,8 @@ cvs.module 		      JSBSim
 depends_lib-append      port:autoconf \
                         port:automake \
                         port:libtool  \
-                        port:tcl
+                        port:tcl \
+			port:pkgconfig
 
 worksrcdir		      JSBSim 
 
@@ -36,7 +37,10 @@ patchfiles              patch-src-Makefile-am.diff \
                         patch-src-simgear-props-Makefile-am.diff \
                         patch-src-simgear-xml-Makefile-am.diff \
                         patch-src-simgear-structure-Makefile-am.diff \
-			patch-src-input_output-string_utilities-h.diff
+			patch-src-input_output-string_utilities-h.diff \
+			patch-add-pkgconfig-in.diff \
+			patch-gen-pkgconfig.diff \
+			patch-makefile-add-pkgconfig.diff
 
 use_configure           yes
 pre-configure {

--- a/darwin/macports/ports/devel/jsbsim/files/patch-add-pkgconfig-in.diff
+++ b/darwin/macports/ports/devel/jsbsim/files/patch-add-pkgconfig-in.diff
@@ -1,0 +1,17 @@
+## Description: add some description
+## Origin/Author: add some origin or author
+## Bug: bug URL
+Index: JSBSim.pc.in
+===================================================================
+--- /dev/null		1970-01-01 00:00:00.000000000 +0000
++++ JSBSim.pc.in	2012-02-04 14:55:37.770723355 +0100
+@@ -0,0 +1,9 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++Name: JSBSim
++Description: JSBSim (Paparazzi version)
++Version: @VERSION@
++Libs: -L${libdir} -lJSBSim
++Cflags: -I${includedir}/JSBSim

--- a/darwin/macports/ports/devel/jsbsim/files/patch-gen-pkgconfig.diff
+++ b/darwin/macports/ports/devel/jsbsim/files/patch-gen-pkgconfig.diff
@@ -1,0 +1,15 @@
+## Description: add some description
+## Origin/Author: add some origin or author
+## Bug: bug URL
+Index: configure.in
+===================================================================
+--- configure.in-orig	2011-12-13 05:55:23.000000000 +0100
++++ configure.in	2012-06-13 01:40:29.407083693 +0200
+@@ -84,6 +84,7 @@
+ 
+ AC_OUTPUT( \
+ Makefile \
++JSBSim.pc \
+ src/Makefile \
+ src/initialization/Makefile \
+ src/models/Makefile \

--- a/darwin/macports/ports/devel/jsbsim/files/patch-makefile-add-pkgconfig.diff
+++ b/darwin/macports/ports/devel/jsbsim/files/patch-makefile-add-pkgconfig.diff
@@ -1,0 +1,17 @@
+## Description: add some description
+## Origin/Author: add some origin or author
+## Bug: bug URL
+Index: Makefile.am
+===================================================================
+--- Makefile.am-orig	2012-02-03 21:38:39.437567187 +0100
++++ Makefile.am		2012-02-03 21:38:37.849567149 +0100
+@@ -3,6 +3,9 @@
+ 
+ SUBDIRS	= src systems aircraft engine scripts data_output data_plot check_cases examples
+ 
++pkgconfigdir = $(libdir)/pkgconfig
++pkgconfig_DATA = JSBSim.pc
++
+ dist-hook:
+ 	(cd $(top_srcdir))
+ 


### PR DESCRIPTION
With this patch the simulation targets should be able to detect jsbsim again on the OS X platform too. Submitting for peer testing.
